### PR TITLE
Add backwards compatibility

### DIFF
--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -110,7 +110,7 @@ extern "C" {
 #define tr_cmdline(...)         mbed_tracef(TRACE_LEVEL_CMD,     TRACE_GROUP, __VA_ARGS__)   //!< Special print for cmdline. See more from TRACE_LEVEL_CMD -level
 
 /** Possible to skip all traces in compile time */
-#if defined(YOTTA_CFG_MBED_TRACE)
+#if defined(YOTTA_CFG_MBED_TRACE) || defined(HAVE_DEBUG) || (defined(YOTTA_CFG) && !defined(NDEBUG))
 
 #if defined(__GNUC__) || defined(__CC_ARM)
 /**

--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -28,7 +28,7 @@
 #include "mbed-trace/mbed_trace_ip6tos.h"
 #endif
 
-#if defined(_WIN32) || defined(__unix__) || defined(__unix) || defined(unix) || defined(YOTTA_CFG)
+#if defined(_WIN32) || defined(__unix__) || defined(__unix) || defined(unix) || (defined(YOTTA_CFG) && !defined(NDEBUG))
 #ifndef MEM_ALLOC
 #define MEM_ALLOC malloc
 #endif
@@ -259,6 +259,9 @@ static void mbed_trace_default_print(const char *str)
 }
 void mbed_tracef(uint8_t dlevel, const char *grp, const char *fmt, ...)
 {
+    if (NULL == m_trace.line) {
+        return;
+    }
     m_trace.line[0] = 0; //by default trace is empty
 
     if (mbed_trace_skip(dlevel, grp) || fmt == 0 || grp == 0 || !m_trace.printf) {


### PR DESCRIPTION
Old dependencies may cause crash otherwise

@jupe could you check this? Need to add one check and some more flags for compatibility.