### PR TITLE
remove default TRACE_GROUP

### DIFF
--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -121,8 +121,6 @@ extern "C" {
 #define TRACE_GROUP_STR_HELPER(x) #x
 #define TRACE_GROUP_STR(x) TRACE_GROUP_STR_HELPER(x)
 #define TRACE_GROUP TRACE_GROUP_STR(YOTTA_CFG_MBED_TRACE_GROUP)
-#else
-#define TRACE_GROUP "APPL"
 #endif
 #endif
 


### PR DESCRIPTION
@SeppoTakalo @jupe @marhil01 @yogpan01 

It might be better to remove the default TRACE_GROUP definition as it may cause TRACE_GROUP refinition issues for users.

I added this default definition here mainly to avoid any compilation fails in case user tries to use tracing functions, but has not defined any TRACE_GROUP's.