### PR TITLE
Adding Makefile for mbed-trace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ UNITTESTS := $(sort $(dir $(wildcard $(TEST_FOLDER)*/utest/*)))
 include sources.mk
 include include_dirs.mk
 
-SERVLIB_DIR := ../libService
-override CFLAGS += -I$(SERVLIB_DIR)/libService
 override CFLAGS += $(addprefix -I,$(INCLUDE_DIRS))
 override CFLAGS += $(addprefix -D,$(FLAGS))
 ifeq ($(DEBUG),1)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+#
+# Makefile for mbed Client C++ Library
+#
+# List of subdirectories to build
+TEST_FOLDER := ./test/
+
+# Define compiler toolchain with CC or PLATFORM variables
+# Example (GCC toolchains, default $CC and $AR are used)
+# make
+#
+# OR (Cross-compile GCC toolchain)
+# make PLATFORM=arm-linux-gnueabi-
+#
+# OR (ArmCC/Keil)
+# make CC=ArmCC AR=ArmAR
+#
+# OR (IAR-ARM)
+# make CC=iccarm
+
+LIB = libmbed-trace.a
+
+# List of unit test directories for libraries
+UNITTESTS := $(sort $(dir $(wildcard $(TEST_FOLDER)*/utest/*)))
+
+
+include sources.mk
+include include_dirs.mk
+
+SERVLIB_DIR := ../libService
+override CFLAGS += -I$(SERVLIB_DIR)/libService
+override CFLAGS += $(addprefix -I,$(INCLUDE_DIRS))
+override CFLAGS += $(addprefix -D,$(FLAGS))
+ifeq ($(DEBUG),1)
+override CFLAGS += -DHAVE_DEBUG
+endif
+
+COVERAGEFILE := ./lcov/coverage.info
+
+#
+# Define compiler toolchain
+#
+include ../libService/toolchain_rules.mk
+
+$(eval $(call generate_rules,$(LIB),$(SRCS)))
+
+# Extend default clean rule
+clean: clean-extra
+
+$(CLEANDIRS):
+	@make -C $(@:clean-%=%) clean
+
+clean-extra: $(CLEANDIRS)

--- a/include_dirs.mk
+++ b/include_dirs.mk
@@ -1,0 +1,7 @@
+INCLUDE_DIRS := \
+	../ \
+	. \
+	../libService/libService \
+
+
+

--- a/sources.mk
+++ b/sources.mk
@@ -1,0 +1,6 @@
+SRCS += \
+	source/mbed_trace.c \
+	source/mbed_trace_ip6tos.c \	
+
+
+


### PR DESCRIPTION
First draft of Makefile support for mbed-trace.
It is not tested for all compiler configurations.
Tested with "make CC=gcc"