### PR TITLE
Add nanostack-libservice lib to CMakeLists

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,10 +3,10 @@ if(DEFINED TARGET_LIKE_X86_LINUX_NATIVE)
         mbed_trace.c
     )
     add_definitions("-g -O0 -fprofile-arcs -ftest-coverage")
-    target_link_libraries(mbed-trace gcov)
+    target_link_libraries(mbed-trace gcov nanostack-libservice)
 else()
     add_library( mbed-trace
         mbed_trace.c
     )
-    target_link_libraries(mbed-trace)
+    target_link_libraries(mbed-trace nanostack-libservice)
 endif()


### PR DESCRIPTION
@jupe 
This won't build in yotta if nanostack-libservice library is not included when linking.