### PR TITLE
Fix #34: Do not try to use a va_list twice

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -368,7 +368,10 @@ void mbed_vtracef(uint8_t dlevel, const char* grp, const char *fmt, va_list ap)
             if (bLeft > 0 && m_trace.prefix_f) {
                 //find out length of body
                 size_t sz = 0;
-                sz = vsnprintf(NULL, 0, fmt, ap) + retval + (retval ? 4 : 0);
+                va_list ap2;
+                va_copy(ap2, ap);
+                sz = vsnprintf(NULL, 0, fmt, ap2) + retval + (retval ? 4 : 0);
+                va_end(ap2);
                 //add prefix string
                 retval = snprintf(ptr, bLeft, "%s", m_trace.prefix_f(sz));
                 if (retval >= bLeft) {

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -333,8 +333,8 @@ TEST(trace, prefix)
 {
   mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ALL);
   mbed_trace_prefix_function_set( &trace_prefix );
-  mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "test");
-  STRCMP_EQUAL("[<TIME>][DBG ][mygr]: test", buf);
+  mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "test %d %d", 1, 2);
+  STRCMP_EQUAL("[<TIME>][DBG ][mygr]: test 1 2", buf);
   //TEST_ASSERT_EQUAL_INT(4, time_length);
   
   mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ALL|TRACE_MODE_PLAIN);


### PR DESCRIPTION
If the prefix function was set, mbed_vtracef would pass ap to vsnprintf to
determine the output length, then use ap again for the actual output,
running off the real arguments.

Create a copy of ap for the initial scan. (Thank you to C99, who added
va_copy. Would have been stuck without it.)