### PR TITLE
FEA_TRACE_SUPPORT flag is always set when traces are enabled.

### DIFF
--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -339,6 +339,10 @@ char* mbed_trace_array(const uint8_t* buf, uint16_t len);
  * surrounding the name of the function with brackets, e.g. "(mbed_tracef)(dlevel, grp, "like so");"
  * */
 #if defined(FEA_TRACE_SUPPORT) || MBED_CONF_MBED_TRACE_ENABLE || defined(YOTTA_CFG_MBED_TRACE) || (defined(YOTTA_CFG) && !defined(NDEBUG))
+// Make sure FEA_TRACE_SUPPORT is always set whenever traces are enabled.
+#ifndef FEA_TRACE_SUPPORT
+#define FEA_TRACE_SUPPORT
+#endif
 // undefine dummies, revealing the real functions
 #undef MBED_TRACE_DUMMIES_DEFINED
 #undef mbed_trace_init


### PR DESCRIPTION
There are multiple build environments that all use different configuration methods,
which results in multiple supported trace enable flags.
This ensures that regardless of which flag/combination of flags was used to enable traces
at least one flag, FEA_TRACE_SUPPORT, is always set.