### PR TITLE
Deprecate the misnamed YOTTA_CFG_MTRACE_TMP_LINE_LENGTH flag.

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -58,8 +58,11 @@
 #define DEFAULT_TRACE_LINE_LENGTH         1024
 #endif
 /** default max temporary buffer size in bytes, used in
-    trace_ipv6, trace_array and trace_strn */
-#ifdef YOTTA_CFG_MTRACE_TMP_LINE_LEN
+    trace_ipv6, trace_ipv6_prefix and trace_array */
+#ifdef YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN
+#define DEFAULT_TRACE_TMP_LINE_LEN        YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN
+#elif defined YOTTA_CFG_MTRACE_TMP_LINE_LEN
+#warning The YOTTA_CFG_MTRACE_TMP_LINE_LEN flag is deprecated! Use YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN instead.
 #define DEFAULT_TRACE_TMP_LINE_LEN        YOTTA_CFG_MTRACE_TMP_LINE_LEN
 #else
 #define DEFAULT_TRACE_TMP_LINE_LEN        128


### PR DESCRIPTION
Configuring the tmp line length value through config.json in yotta requires defining a separate "mtrace" group, because the name of the flag doesn't follow the 'YOTTA_CFG_MBED_TRACE_' pattern.

This allows configuring the tmp line length in the same group mbed-trace is enabled in.

(The name of the flag seems to be a relic of the time the name of the library was still being decided.
For some reason it wasn't changed with the other ones when 'mbed-trace' was decided on.)