### PR TITLE
Fix disabling traces through the YOTTA_CFG_MBED_TRACE flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The purpose of the library is to provide a light, simple and general tracing sol
 
 * Initialize the serial port so that `stdout` works. You can verify that the serial port works using the `printf()` function.
  * if you want to redirect the traces somewhere else, see the [trace API](https://github.com/ARMmbed/mbed-trace/blob/master/mbed-trace/mbed_trace.h#L170).
-* to activate traces, configure yotta with flag: `YOTTA_CFG_MBED_TRACE`
+* to activate traces, configure yotta with flag: `YOTTA_CFG_MBED_TRACE` set to 1 or true. Setting the flag to 0 or false disables tracing.
  * By default trace uses 1024 bytes buffer for trace lines, but it can be configure by yotta with: `YOTTA_CFG_MBED_TRACE_LINE_LENGTH`. Default length: 1024.
  * To disable ipv6 convertion, set `YOTTA_CFG_MBED_TRACE_FEA_IPV6 = 0` from yotta configurations.
 * Call the trace initialization (`mbed_trace_init`) once before using any other APIs. It allocates the trace buffer and initializes the internal variables.
@@ -98,7 +98,7 @@ See more in [mbed_trace.h](https://github.com/ARMmbed/mbed-trace/blob/master/mbe
 ## Usage example:
 
 ```c++
-#define YOTTA_CFG_MBED_TRACE //this can be defined also in the yotta configuration file config.yml
+#define YOTTA_CFG_MBED_TRACE 1 //this can be defined also in the yotta configuration file config.json
 #include "mbed-trace/mbed_trace.h"
 #define TRACE_GROUP  "main"
 

--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -57,6 +57,10 @@ extern "C" {
 
 #include <stdarg.h>
 
+#ifndef YOTTA_CFG_MBED_TRACE
+#define YOTTA_CFG_MBED_TRACE 0
+#endif
+
 #ifndef YOTTA_CFG_MBED_TRACE_FEA_IPV6
 #define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
 #endif
@@ -338,7 +342,7 @@ char* mbed_trace_array(const uint8_t* buf, uint16_t len);
  * If tracing is disabled, the dummies will hide the real functions. The real functions can still be reached by
  * surrounding the name of the function with brackets, e.g. "(mbed_tracef)(dlevel, grp, "like so");"
  * */
-#if defined(FEA_TRACE_SUPPORT) || MBED_CONF_MBED_TRACE_ENABLE || defined(YOTTA_CFG_MBED_TRACE) || (defined(YOTTA_CFG) && !defined(NDEBUG))
+#if defined(FEA_TRACE_SUPPORT) || MBED_CONF_MBED_TRACE_ENABLE || YOTTA_CFG_MBED_TRACE || (defined(YOTTA_CFG) && !defined(NDEBUG))
 // Make sure FEA_TRACE_SUPPORT is always set whenever traces are enabled.
 #ifndef FEA_TRACE_SUPPORT
 #define FEA_TRACE_SUPPORT

--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -18,7 +18,7 @@
 #include <stdarg.h>
 
 #ifndef YOTTA_CFG_MBED_TRACE
-#define YOTTA_CFG_MBED_TRACE
+#define YOTTA_CFG_MBED_TRACE 1
 #define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
 #endif
 

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -14,7 +14,7 @@
 #include "mbed-cpputest/CppUTest/SimpleString.h"
 #include "mbed-cpputest/CppUTest/CommandLineTestRunner.h"
 
-#define YOTTA_CFG_MBED_TRACE
+#define YOTTA_CFG_MBED_TRACE 1
 #define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
 
 #include "mbed-trace/mbed_trace.h"


### PR DESCRIPTION
Previously only the existence of the flag was checked. Thus tracing was always enabled if the flag was defined regardless of its actual value, including when it was defined as 0 or false.

Now tracing is enabled when YOTTA_CFG_MBED_TRACE is defined as an empty define (which was previously accepted), 1 or true.
Tracing is disabled when the flag is undefined, or defined as 0 or false.