### PR TITLE
Add instructions for enabling the library in mbed OS 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To do so, add the following to your mbed_app.json:
 }
 ```
 
-Don't forget to fulfill the other [prerequisites](prerequisites)!
+Don't forget to fulfill the other [prerequisites](#prerequisites)!
 
 ([Click here for more information on the configuration system](https://github.com/ARMmbed/mbed-os/blob/master/docs/config_system.md))
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,33 @@ The purpose of the library is to provide a light, simple and general tracing sol
 
 * Initialize the serial port so that `stdout` works. You can verify that the serial port works using the `printf()` function.
     * if you want to redirect the traces somewhere else, see the [trace API](https://github.com/ARMmbed/mbed-trace/blob/master/mbed-trace/mbed_trace.h#L170).
-* To activate traces, set `YOTTA_CFG_MBED_TRACE` to 1 or true. Setting the flag to 0 or false disables tracing.
+* To activate traces:
+    * With yotta: set `YOTTA_CFG_MBED_TRACE` to 1 or true. Setting the flag to 0 or false disables tracing.
+    * [With mbed OS 5](#enabling-traces-in-mbed-os-5)
 * By default, trace uses 1024 bytes buffer for trace lines, but you can change it by yotta with: `YOTTA_CFG_MBED_TRACE_LINE_LENGTH`.
 * To disable the IPv6 conversion, set `YOTTA_CFG_MBED_TRACE_FEA_IPV6 = 0`.
 * If thread safety is needed, configure the wait and release callback functions before initialization to enable the protection. Usually, this needs to be done only once in the application's lifetime.
 * Call the trace initialization (`mbed_trace_init`) once before using any other APIs. It allocates the trace buffer and initializes the internal variables.
 * Define `TRACE_GROUP` in your source code (not in the header!) to use traces. It is a 1-4 characters long char-array (for example `#define TRACE_GROUP "APPL"`). This will be printed on every trace line.
+
+### Enabling traces in mbed OS 5
+
+To enable traces in mbed OS 5, you need to add the feature COMMON_PAL into the build and enable the trace library.
+
+To do so, add the following to your mbed_app.json:
+
+```json
+{
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["COMMON_PAL"],
+            "mbed-trace.enable": 1
+        }
+    }
+}
+```
+
+([Click here for more information on the configuration system](https://github.com/ARMmbed/mbed-os/blob/master/docs/config_system.md))
 
 ### Traces
 

--- a/README.md
+++ b/README.md
@@ -44,18 +44,19 @@ The purpose of the library is to provide a light, simple and general tracing sol
 
 * Initialize the serial port so that `stdout` works. You can verify that the serial port works using the `printf()` function.
     * if you want to redirect the traces somewhere else, see the [trace API](https://github.com/ARMmbed/mbed-trace/blob/master/mbed-trace/mbed_trace.h#L170).
-* To activate traces:
+* To enable the tracing API:
     * With yotta: set `YOTTA_CFG_MBED_TRACE` to 1 or true. Setting the flag to 0 or false disables tracing.
-    * [With mbed OS 5](#enabling-traces-in-mbed-os-5)
+    * [With mbed OS 5](#enabling-the-tracing-api-in-mbed-os-5)
 * By default, trace uses 1024 bytes buffer for trace lines, but you can change it by yotta with: `YOTTA_CFG_MBED_TRACE_LINE_LENGTH`.
 * To disable the IPv6 conversion, set `YOTTA_CFG_MBED_TRACE_FEA_IPV6 = 0`.
 * If thread safety is needed, configure the wait and release callback functions before initialization to enable the protection. Usually, this needs to be done only once in the application's lifetime.
 * Call the trace initialization (`mbed_trace_init`) once before using any other APIs. It allocates the trace buffer and initializes the internal variables.
 * Define `TRACE_GROUP` in your source code (not in the header!) to use traces. It is a 1-4 characters long char-array (for example `#define TRACE_GROUP "APPL"`). This will be printed on every trace line.
 
-### Enabling traces in mbed OS 5
+### Enabling the tracing API in mbed OS 5
 
-To enable traces in mbed OS 5, you need to add the feature COMMON_PAL into the build and enable the trace library.
+* Add the feature COMMON_PAL into the build
+* Set `MBED_CONF_MBED_TRACE_ENABLE` to 1 or true
 
 To do so, add the following to your mbed_app.json:
 
@@ -69,6 +70,8 @@ To do so, add the following to your mbed_app.json:
     }
 }
 ```
+
+Don't forget to fulfill the other [prerequisites](prerequisites)!
 
 ([Click here for more information on the configuration system](https://github.com/ARMmbed/mbed-os/blob/master/docs/config_system.md))
 


### PR DESCRIPTION
Added instructions for enabling the tracing API in mbed OS 5.

Also slightly clarified the text to avoid implying that simply enabling the API is sufficient to enable tracing.