### PR TITLE
Fix race condition when unlocking mutex

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -454,7 +454,8 @@ void mbed_vtracef(uint8_t dlevel, const char* grp, const char *fmt, va_list ap)
 
 end:
     if ( m_trace.mutex_release_f ) {
-        for ( ;m_trace.mutex_lock_count > 0; m_trace.mutex_lock_count-- ) {
+        while (m_trace.mutex_lock_count > 0) {
+            m_trace.mutex_lock_count--;
             m_trace.mutex_release_f();
         }
     }


### PR DESCRIPTION
Fixes issue where mutex might be left locked when leaving mbed_vtracef function because of decreasing mutex_lock_count after releasing the mutex.