### PR TITLE
Provide environment-agnostic configuration macros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ The purpose of the library is to provide a light, simple and general tracing sol
 * To enable the tracing API:
     * With yotta: set `YOTTA_CFG_MBED_TRACE` to 1 or true. Setting the flag to 0 or false disables tracing.
     * [With mbed OS 5](#enabling-the-tracing-api-in-mbed-os-5)
-* By default, trace uses 1024 bytes buffer for trace lines, but you can change it by yotta with: `YOTTA_CFG_MBED_TRACE_LINE_LENGTH`.
-* To disable the IPv6 conversion, set `YOTTA_CFG_MBED_TRACE_FEA_IPV6 = 0`.
+* By default, trace uses 1024 bytes buffer for trace lines, but you can change it by setting the configuration macro `MBED_TRACE_LINE_LENGTH` to the desired value.
+* To disable the IPv6 conversion:
+    * With yotta: set `YOTTA_CFG_MBED_TRACE_FEA_IPV6 = 0`.
+    * With mbed OS 5: set `MBED_CONF_MBED_TRACE_FEA_IPV6 = 0`.
 * If thread safety is needed, configure the wait and release callback functions before initialization to enable the protection. Usually, this needs to be done only once in the application's lifetime.
 * Call the trace initialization (`mbed_trace_init`) once before using any other APIs. It allocates the trace buffer and initializes the internal variables.
 * Define `TRACE_GROUP` in your source code (not in the header!) to use traces. It is a 1-4 characters long char-array (for example `#define TRACE_GROUP "APPL"`). This will be printed on every trace line.
@@ -128,7 +130,7 @@ See more in [mbed_trace.h](https://github.com/ARMmbed/mbed-trace/blob/master/mbe
 ## Usage example:
 
 ```c++
-#define YOTTA_CFG_MBED_TRACE 1 //this can be defined also in the yotta configuration file config.json
+#define MBED_CONF_MBED_TRACE_ENABLE 1 //this could be defined also in the mbed-cli configuration file mbed_app.json
 #include "mbed-trace/mbed_trace.h"
 #define TRACE_GROUP  "main"
 

--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -64,10 +64,17 @@ extern "C" {
 
 #ifndef YOTTA_CFG_MBED_TRACE_FEA_IPV6
 #define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
+#else
+#warning YOTTA_CFG_MBED_TRACE_FEA_IPV6 is deprecated and will be removed in the future! Use MBED_CONF_MBED_TRACE_FEA_IPV6 instead.
+#define MBED_CONF_MBED_TRACE_FEA_IPV6 YOTTA_CFG_MBED_TRACE_FEA_IPV6
 #endif
 
 #ifndef MBED_CONF_MBED_TRACE_ENABLE
 #define MBED_CONF_MBED_TRACE_ENABLE 0
+#endif
+
+#ifndef MBED_CONF_MBED_TRACE_FEA_IPV6
+#define MBED_CONF_MBED_TRACE_FEA_IPV6 1
 #endif
 
 /** 3 upper bits are trace modes related,
@@ -321,7 +328,7 @@ void mbed_vtracef(uint8_t dlevel, const char* grp, const char *fmt, va_list ap);
  *  Get last trace from buffer
  */
 const char* mbed_trace_last(void);
-#if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1
+#if MBED_CONF_MBED_TRACE_FEA_IPV6 == 1
 /**
  * mbed_tracef helping function for convert ipv6
  * table to human readable string.

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -4,6 +4,11 @@
         "enable": {
             "help": "Used to globally enable traces.",
             "value": null
+        },
+        "fea-ipv6": {
+            "help": "Used to globally disable ipv6 tracing features.",
+            "value": null
         }
+
     }    
 }

--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -17,13 +17,16 @@
 #include <string.h>
 #include <stdarg.h>
 
-#ifndef YOTTA_CFG_MBED_TRACE
-#define YOTTA_CFG_MBED_TRACE 1
-#define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
+#ifdef MBED_CONF_MBED_TRACE_ENABLE
+#undef MBED_CONF_MBED_TRACE_ENABLE
+#endif
+#define MBED_CONF_MBED_TRACE_ENABLE 1
+#ifndef MBED_CONF_MBED_TRACE_FEA_IPV6
+#define MBED_CONF_MBED_TRACE_FEA_IPV6 1
 #endif
 
 #include "mbed-trace/mbed_trace.h"
-#if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1
+#if MBED_CONF_MBED_TRACE_FEA_IPV6 == 1
 #include "mbed-client-libservice/ip6string.h"
 #include "mbed-client-libservice/common_functions.h"
 #endif
@@ -487,7 +490,7 @@ const char *mbed_trace_last(void)
 }
 /* Helping functions */
 #define tmp_data_left()  m_trace.tmp_data_length-(m_trace.tmp_data_ptr-m_trace.tmp_data)
-#if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1
+#if MBED_CONF_MBED_TRACE_FEA_IPV6 == 1
 char *mbed_trace_ipv6(const void *addr_ptr)
 {
     /** Acquire mutex. It is released before returning from mbed_vtracef. */
@@ -531,7 +534,7 @@ char *mbed_trace_ipv6_prefix(const uint8_t *prefix, uint8_t prefix_len)
     m_trace.tmp_data_ptr += ip6_prefix_tos(prefix, prefix_len, str) + 1;
     return str;
 }
-#endif //YOTTA_CFG_MBED_TRACE_FEA_IPV6
+#endif //MBED_CONF_MBED_TRACE_FEA_IPV6
 char *mbed_trace_array(const uint8_t *buf, uint16_t len)
 {
     /** Acquire mutex. It is released before returning from mbed_vtracef. */

--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -55,23 +55,36 @@
 #define VT100_COLOR_DEBUG "\x1b[90m"
 
 /** default max trace line size in bytes */
-#ifdef YOTTA_CFG_MBED_TRACE_LINE_LENGTH
+#ifdef MBED_TRACE_LINE_LENGTH
+#define DEFAULT_TRACE_LINE_LENGTH         MBED_TRACE_LINE_LENGTH
+#elif defined YOTTA_CFG_MBED_TRACE_LINE_LENGTH
+#warning YOTTA_CFG_MBED_TRACE_LINE_LENGTH is deprecated and will be removed in the future! Use MBED_TRACE_LINE_LENGTH instead.
 #define DEFAULT_TRACE_LINE_LENGTH         YOTTA_CFG_MBED_TRACE_LINE_LENGTH
 #else
 #define DEFAULT_TRACE_LINE_LENGTH         1024
 #endif
+
 /** default max temporary buffer size in bytes, used in
     trace_ipv6, trace_ipv6_prefix and trace_array */
-#ifdef YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN
+#ifdef MBED_TRACE_TMP_LINE_LENGTH
+#define DEFAULT_TRACE_TMP_LINE_LEN        MBED_TRACE_TMP_LINE_LENGTH
+#elif defined YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN
+#warning The YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN flag is deprecated and will be removed in the future! Use MBED_TRACE_TMP_LINE_LENGTH instead.
 #define DEFAULT_TRACE_TMP_LINE_LEN        YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN
 #elif defined YOTTA_CFG_MTRACE_TMP_LINE_LEN
-#warning The YOTTA_CFG_MTRACE_TMP_LINE_LEN flag is deprecated! Use YOTTA_CFG_MBED_TRACE_TMP_LINE_LEN instead.
+#warning The YOTTA_CFG_MTRACE_TMP_LINE_LEN flag is deprecated and will be removed in the future! Use MBED_TRACE_TMP_LINE_LENGTH instead.
 #define DEFAULT_TRACE_TMP_LINE_LEN        YOTTA_CFG_MTRACE_TMP_LINE_LEN
 #else
 #define DEFAULT_TRACE_TMP_LINE_LEN        128
 #endif
+
 /** default max filters (include/exclude) length in bytes */
+#ifdef MBED_TRACE_FILTER_LENGTH
+#define DEFAULT_TRACE_FILTER_LENGTH       MBED_TRACE_FILTER_LENGTH
+#else
 #define DEFAULT_TRACE_FILTER_LENGTH       24
+#endif
+
 /** default trace configuration bitmask */
 #ifdef MBED_TRACE_CONFIG
 #define DEFAULT_TRACE_CONFIG              MBED_TRACE_CONFIG

--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -69,6 +69,12 @@
 #endif
 /** default max filters (include/exclude) length in bytes */
 #define DEFAULT_TRACE_FILTER_LENGTH       24
+/** default trace configuration bitmask */
+#ifdef MBED_TRACE_CONFIG
+#define DEFAULT_TRACE_CONFIG              MBED_TRACE_CONFIG
+#else
+#define DEFAULT_TRACE_CONFIG              TRACE_MODE_COLOR | TRACE_ACTIVE_LEVEL_ALL | TRACE_CARRIAGE_RETURN
+#endif
 
 /** default print function, just redirect str to printf */
 static void mbed_trace_realloc( char **buffer, int *length_ptr, int new_length);
@@ -112,13 +118,17 @@ typedef struct trace_s {
 } trace_t;
 
 static trace_t m_trace = {
+    .trace_config = DEFAULT_TRACE_CONFIG,
     .filters_exclude = 0,
     .filters_include = 0,
+    .filters_length = DEFAULT_TRACE_FILTER_LENGTH,
     .line = 0,
+    .line_length = DEFAULT_TRACE_LINE_LENGTH,
     .tmp_data = 0,
+    .tmp_data_length = DEFAULT_TRACE_TMP_LINE_LEN,
     .prefix_f = 0,
     .suffix_f = 0,
-    .printf  = 0,
+    .printf  = mbed_trace_default_print,
     .cmd_printf = 0,
     .mutex_wait_f = 0,
     .mutex_release_f = 0,
@@ -127,17 +137,15 @@ static trace_t m_trace = {
 
 int mbed_trace_init(void)
 {
-    m_trace.trace_config = TRACE_MODE_COLOR | TRACE_ACTIVE_LEVEL_ALL | TRACE_CARRIAGE_RETURN;
-    m_trace.line_length = DEFAULT_TRACE_LINE_LENGTH;
     if (m_trace.line == NULL) {
         m_trace.line = MBED_TRACE_MEM_ALLOC(m_trace.line_length);
     }
-    m_trace.tmp_data_length = DEFAULT_TRACE_TMP_LINE_LEN;
+
     if (m_trace.tmp_data == NULL) {
         m_trace.tmp_data = MBED_TRACE_MEM_ALLOC(m_trace.tmp_data_length);
     }
     m_trace.tmp_data_ptr = m_trace.tmp_data;
-    m_trace.filters_length = DEFAULT_TRACE_FILTER_LENGTH;
+
     if (m_trace.filters_exclude == NULL) {
         m_trace.filters_exclude = MBED_TRACE_MEM_ALLOC(m_trace.filters_length);
     }
@@ -158,29 +166,28 @@ int mbed_trace_init(void)
     memset(m_trace.filters_include, 0, m_trace.filters_length);
     memset(m_trace.line, 0, m_trace.line_length);
 
-    m_trace.prefix_f = 0;
-    m_trace.suffix_f = 0;
-    m_trace.printf = mbed_trace_default_print;
-    m_trace.cmd_printf = 0;
-
     return 0;
 }
 void mbed_trace_free(void)
 {
+    // release memory
     MBED_TRACE_MEM_FREE(m_trace.line);
-    m_trace.line_length = 0;
-    m_trace.line = 0;
     MBED_TRACE_MEM_FREE(m_trace.tmp_data);
-    m_trace.tmp_data = 0;
-    m_trace.tmp_data_ptr = 0;
     MBED_TRACE_MEM_FREE(m_trace.filters_exclude);
-    m_trace.filters_exclude = 0;
     MBED_TRACE_MEM_FREE(m_trace.filters_include);
+
+    // reset to default values
+    m_trace.trace_config = DEFAULT_TRACE_CONFIG;
+    m_trace.filters_exclude = 0;
     m_trace.filters_include = 0;
-    m_trace.filters_length = 0;
+    m_trace.filters_length = DEFAULT_TRACE_FILTER_LENGTH;
+    m_trace.line = 0;
+    m_trace.line_length = DEFAULT_TRACE_LINE_LENGTH;
+    m_trace.tmp_data = 0;
+    m_trace.tmp_data_length = DEFAULT_TRACE_TMP_LINE_LEN;
     m_trace.prefix_f = 0;
     m_trace.suffix_f = 0;
-    m_trace.printf = mbed_trace_default_print;
+    m_trace.printf  = mbed_trace_default_print;
     m_trace.cmd_printf = 0;
     m_trace.mutex_wait_f = 0;
     m_trace.mutex_release_f = 0;

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -14,8 +14,8 @@
 #include "mbed-cpputest/CppUTest/SimpleString.h"
 #include "mbed-cpputest/CppUTest/CommandLineTestRunner.h"
 
-#define YOTTA_CFG_MBED_TRACE 1
-#define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
+#define MBED_CONF_MBED_TRACE_ENABLE 1
+#define MBED_CONF_MBED_TRACE_FEA_IPV6 1
 
 #include "mbed-trace/mbed_trace.h"
 #include "ip6tos_stub.h"

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -118,6 +118,7 @@ TEST(trace, BufferResize)
 {
     uint8_t arr[20] = {0};
     memset(arr, '0', 20);
+
     mbed_trace_buffer_sizes(0, 10);
     STRCMP_EQUAL("30:30:30*", mbed_trace_array(arr, 20));
     mbed_trace_buffer_sizes(0, 15);
@@ -125,7 +126,18 @@ TEST(trace, BufferResize)
     mbed_trace_buffer_sizes(0, 15);
     STRCMP_EQUAL("30:30:30:30", mbed_trace_array(arr, 4));
 
-    mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "flush buffers and locks");
+    const char * expectedStr = "0123456789";
+    mbed_trace_buffer_sizes(11, 0);
+    mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "01234567890123456789");
+    STRCMP_EQUAL(expectedStr, buf);
+    expectedStr = "012345678901234";
+    mbed_trace_buffer_sizes(16, 0);
+    mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "01234567890123456789");
+    STRCMP_EQUAL(expectedStr, buf);
+    expectedStr = "012345678901234";
+    mbed_trace_buffer_sizes(16, 0);
+    mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "012345678901234");
+    STRCMP_EQUAL(expectedStr, buf);
 }
 
 #if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -140,6 +140,26 @@ TEST(trace, BufferResize)
     STRCMP_EQUAL(expectedStr, buf);
 }
 
+TEST(trace, PreInitConfiguration)
+{
+    uint8_t arr[20] = {0};
+    memset(arr, '0', 20);
+
+    mbed_trace_free();
+    mbed_trace_config_set(TRACE_MODE_PLAIN|TRACE_ACTIVE_LEVEL_ALL);
+    mbed_trace_print_function_set( myprint );
+    mbed_trace_buffer_sizes(11, 10);
+    mbed_trace_mutex_wait_function_set( my_mutex_wait );
+    mbed_trace_mutex_release_function_set( my_mutex_release );
+    mbed_trace_init();
+
+    STRCMP_EQUAL("30:30:30*", mbed_trace_array(arr, 20));
+
+    const char * expectedStr = "0123456789";
+    mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "01234567890123456789");
+    STRCMP_EQUAL(expectedStr, buf);
+}
+
 #if YOTTA_CFG_MBED_TRACE_FEA_IPV6 == 1
 ip6tos_stub_def_t ip6tos_stub; // extern variable
 


### PR DESCRIPTION
* MBED_TRACE_LINE_LENGTH
    default max trace line size in bytes
* MBED_TRACE_TMP_LINE_LENGTH
    default max temporary buffer size in bytes,
    used by trace_ipv6, trace_ipv6_prefix and trace_array
* MBED_TRACE_FILTER_LENGTH
    default maximum length available to include and exclude filters in bytes
* MBED_TRACE_CONFIG
    default trace configuration bitmask
-------
* Add support for MBED_CONF_MBED_TRACE_FEA_IPV6 flag.
-------
* Allow configuration before initialization at runtime.
* Add testcases:
    Resize main trace buffer.
    Configure library before initialization at runtime.