### PR TITLE
Ensure tr_array doesn't print <null> when len == 0

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -558,7 +558,7 @@ char *mbed_trace_array(const uint8_t *buf, uint16_t len)
     int i, bLeft = tmp_data_left();
     char *str, *wptr;
     str = m_trace.tmp_data_ptr;
-    if (str == NULL || bLeft == 0) {
+    if (len == 0 || str == NULL || bLeft == 0) {
         return "";
     }
     if (buf == NULL) {

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -91,6 +91,19 @@ TEST(trace, Array)
   mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "%s", mbed_trace_array(longStr, 200) );
 }
 
+TEST(trace, Null0Array)
+{
+  static const unsigned char array[2] = { 0x23, 0x45 };
+  mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "%s", mbed_trace_array(array, 2));
+  STRCMP_EQUAL("23:45", buf);
+  mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "%s", mbed_trace_array(array, 0));
+  STRCMP_EQUAL("", buf);
+  mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "%s", mbed_trace_array(NULL, 0));
+  STRCMP_EQUAL("", buf);
+  mbed_tracef(TRACE_LEVEL_DEBUG, "mygr", "%s", mbed_trace_array(NULL, 2));
+  STRCMP_EQUAL("<null>", buf);
+}
+
 TEST(trace, LongString)
 {
   char longStr[1000] = {0x36};


### PR DESCRIPTION
tr_array(NULL, 0) would output `"<null>"` - this is unhelpful, as
a number of parts of the system regard (NULL, 0) as being a legal
empty value. Make this output `""` instead.