### PR TITLE
fix dummydefine for mbed_trace_init

### DIFF
--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -408,7 +408,7 @@ char* mbed_trace_array(const uint8_t* buf, uint16_t len);
 #elif !defined(MBED_TRACE_DUMMIES_DEFINED)
 // define dummies, hiding the real functions
 #define MBED_TRACE_DUMMIES_DEFINED
-#define mbed_trace_init(...)                        ((void) 0)
+#define mbed_trace_init(...)                        ((int) 0)
 #define mbed_trace_free(...)                        ((void) 0)
 #define mbed_trace_buffer_sizes(...)                ((void) 0)
 #define mbed_trace_config_set(...)                  ((void) 0)


### PR DESCRIPTION
## Status
**READY**

## Description
This is fixing issue #70:  when `MBED_CONF_MBED_TRACE_ENABLE=0` and application uses return value from `mbed_trace_init()` - `mbed_trace` didn't define dummy macro right way and causes compling error: 
```
a value of type "void" cannot be assigned to an entity of type "int"
```

## Todo
- [x] Test (manually tested)