### PR TITLE
Added multithreaded lock test.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,8 @@ if(DEFINED TARGET_LIKE_X86_WINDOWS_NATIVE OR DEFINED TARGET_LIKE_X86_LINUX_NATIV
     endif()
     if(DEFINED TARGET_LIKE_X86_LINUX_NATIVE)
         SET(TEST_EXECUTABLE "../../../build/x86-linux-native/test/mbed_trace_test")
+        find_package (Threads)
+        target_link_libraries (mbed_trace_test ${CMAKE_THREAD_LIBS_INIT})
         add_test(mbed_trace_test ${TEST_EXECUTABLE})
         add_dependencies(all_tests mbed_trace_test)
     endif()

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -495,12 +495,12 @@ TEST(trace, multithread)
 
     for(int j=0; j<10; j++)
     {
-      for(int i=0; i<(sizeof(threads)/sizeof(pthread_t)); i++) {
+      for(int i=0; i<thread_amount; i++) {
           //printf("creating %d\n", i);
           thread_indexes[i] = i;
           pthread_create(&threads[i], NULL, &multithread_printer, (void *)&thread_indexes[i]);
       }
-      for(int i=0; i<(sizeof(threads)/sizeof(pthread_t)); i++) {
+      for(int i=0; i<thread_amount; i++) {
           //printf("joining %d\n", i);
           pthread_join(threads[i], NULL);
       }

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -492,15 +492,16 @@ TEST(trace, multithread)
     const int thread_amount = 10;
     pthread_t threads[thread_amount];
     int thread_indexes[thread_amount];
+    int i, j;
 
-    for(int j=0; j<10; j++)
+    for(j=0; j<10; j++)
     {
-      for(int i=0; i<thread_amount; i++) {
+      for(i=0; i<thread_amount; i++) {
           //printf("creating %d\n", i);
           thread_indexes[i] = i;
           pthread_create(&threads[i], NULL, &multithread_printer, (void *)&thread_indexes[i]);
       }
-      for(int i=0; i<thread_amount; i++) {
+      for(i=0; i<thread_amount; i++) {
           //printf("joining %d\n", i);
           pthread_join(threads[i], NULL);
       }


### PR DESCRIPTION
This should detect issues with uneven locking and releasing.

Test flow:
1. Create 10 threads.
1. Each thread calls mbed_tracef() with different delays 10 times.
1. Join 10 threads.
1. Repeat 10 times.
