### PR TITLE
Remove dependency to Nanomesh headers

### DIFF
--- a/mbed-trace/mbed_trace.h
+++ b/mbed-trace/mbed_trace.h
@@ -48,14 +48,9 @@
 extern "C" {
 #endif
 
-#ifdef YOTTA_CFG
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#else
-#include "ns_types.h"
-#endif
-
 #include <stdarg.h>
 
 #ifndef YOTTA_CFG_MBED_TRACE


### PR DESCRIPTION
This library only uses types which are defined in `stdint.h` or `stdbool.h`, therefore it does not need dependency to Namesh libservices, which have much more compiler tweaks.
