### PR TITLE
Fix an implicit truncation of integer

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -556,7 +556,8 @@ char *mbed_trace_array(const uint8_t *buf, uint16_t len)
         m_trace.mutex_wait_f();
         m_trace.mutex_lock_count++;
     }
-    int i, bLeft = tmp_data_left();
+    int i;
+    size_t bLeft = tmp_data_left();
     char *str, *wptr;
     str = m_trace.tmp_data_ptr;
     if (len == 0 || str == NULL || bLeft == 0) {


### PR DESCRIPTION
This fixes a compiler warning:

```
mbed-trace\source\mbed_trace.c(559): warning C4244: 'initializing': conversion from '__int64' to 'int', possible loss of data
```