### PR TITLE
Disable colors by default

### DIFF
--- a/source/mbed_trace.c
+++ b/source/mbed_trace.c
@@ -98,7 +98,7 @@
 #ifdef MBED_TRACE_CONFIG
 #define DEFAULT_TRACE_CONFIG              MBED_TRACE_CONFIG
 #else
-#define DEFAULT_TRACE_CONFIG              TRACE_MODE_COLOR | TRACE_ACTIVE_LEVEL_ALL | TRACE_CARRIAGE_RETURN
+#define DEFAULT_TRACE_CONFIG              TRACE_ACTIVE_LEVEL_ALL | TRACE_CARRIAGE_RETURN
 #endif
 
 /** default print function, just redirect str to printf */


### PR DESCRIPTION
They create more hassle than value right now. For example when viewing the saved logs in an editor, you get the control sequences instead of the colors. Also, Linux systemd does not like those at all.

```

Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [71B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [50B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [69B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [71B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [80B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [98B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [92B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [94B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [74B blob data]
Oct 28 12:09:03 sla-device mbedCloudClientExample.elf[836]: [73B blob data]
```

Blob data is not very useful for anyone.

Disable them by default.